### PR TITLE
Fix crash on BarChart & LineChart while drawing chart with only 0 values

### DIFF
--- a/charts/src/commonMain/kotlin/com/netguru/charts/grid/GridChartDrawing.kt
+++ b/charts/src/commonMain/kotlin/com/netguru/charts/grid/GridChartDrawing.kt
@@ -58,7 +58,13 @@ private fun measureHorizontalLines(
 ): List<LineParameters> {
     val horizontalLines = mutableListOf<LineParameters>()
 
-    if (axisScale.max == axisScale.min || axisScale.tick == 0f) return emptyList()
+    if (axisScale.max == axisScale.min || axisScale.tick == 0f)
+        return listOf(
+            LineParameters(
+                position = startPosition / 2f,
+                value = 0
+            )
+        )
 
     val valueStep = axisScale.tick
     var currentValue = axisScale.min


### PR DESCRIPTION
### Task
<!-- Add links to JIRA task and other relevant resources -->
- [JIRA](https://netguru.atlassian.net/browse/BN-3899)

### Description
When there are only 0 values we return one `LineParameters` instead of `emptyList()`.

![image](https://user-images.githubusercontent.com/9135662/180439494-6f5b1ce2-4e55-4e10-8454-19cfdad67157.png)

